### PR TITLE
Update cla.yml

### DIFF
--- a/actions/cla.yml
+++ b/actions/cla.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   CLA-Lite:
     name: "Signature"
-    timeout-minutes: 10
     uses: rdkcentral/cmf-actions/.github/workflows/cla.yml@latest
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ASSISTANT }}


### PR DESCRIPTION
`timeout-minutes` removed since it's not valid for reusable workflows