### PR TITLE
feat: upgrade CLA action to v2.7.0

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,10 +9,6 @@ permissions:
   actions: write
   contents: read # this can be 'read' if the signatures are in remote repository
   pull-requests: write
-  # Note: v2.7.0+ uses @actions/core built-ins (core.summary, core.warning, core.setFailed)
-  # which don't require explicit API permissions. The CheckRun is auto-created by Actions runtime.
-  # statuses: write - REMOVED in v2.7.0 (no longer uses Status Context API)
-  # checks: write - NOT NEEDED (CheckRun created automatically by GitHub Actions)
 
 jobs:
   CLA-Lite:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: (startsWith(github.event.comment.body, 'recheck') || startsWith(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
-        uses: rdkcentral/contributor-assistant_github-action@v2.6.3
+        uses: rdkcentral/contributor-assistant_github-action@v2.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret
@@ -27,7 +27,7 @@ jobs:
           remote-organization-name: 'rdkcentral'
           remote-repository-name: 'cla_signatures'
           path-to-signatures: 'signatures.json'
-          
+
           path-to-document: 'https://gist.github.com/rdkcmf-jenkins/c797df2d0f276bbae7c2b394e895c263' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'main'
@@ -35,9 +35,6 @@ jobs:
 
           # whitelisted domains
           domain-allow-list-file: 'domains.json'
-
-          # status context (for manually setting status)
-          status-context: 'Signature / Check'
 
          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #domain-allow-list: email domains in the allow list don't have to sign the CLA document

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,7 +9,10 @@ permissions:
   actions: write
   contents: read # this can be 'read' if the signatures are in remote repository
   pull-requests: write
-  statuses: write
+  # Note: v2.7.0+ uses @actions/core built-ins (core.summary, core.warning, core.setFailed)
+  # which don't require explicit API permissions. The CheckRun is auto-created by Actions runtime.
+  # statuses: write - REMOVED in v2.7.0 (no longer uses Status Context API)
+  # checks: write - NOT NEEDED (CheckRun created automatically by GitHub Actions)
 
 jobs:
   CLA-Lite:


### PR DESCRIPTION
## Summary

Upgrades the CLA action from v2.6.3 to v2.7.0 to get enhanced feedback features.

## Changes

- Update `rdkcentral/contributor-assistant_github-action` from v2.6.3 to v2.7.0
- Remove deprecated `status-context` input (now creates check runs only)

## What's New in v2.7.0

- **Enhanced job summaries** with HTML formatted tables
- **Check run annotations** visible in Annotations section
- **Removes duplicate status checks** (StatusContext deprecated)
- Improved error messaging and user experience

## Breaking Changes

None - fully backwards compatible.

## Testing

Tested on rdkcentral/cmf-release-app PR #27 with unsigned contributors.

## Related

- Tag: rdkcentral/contributor-assistant_github-action@v2.7.0
- Test PR: rdkcentral/cmf-release-app#27